### PR TITLE
Updated initialize to use godotsteam_multiplayer_peer dir

### DIFF
--- a/register_types.cpp
+++ b/register_types.cpp
@@ -6,12 +6,12 @@
 #include "godotsteam_multiplayer_peer.h"
 
 
-void initialize_godotsteam_multiplayer_module(ModuleInitializationLevel level) {
+void initialize_godotsteam_multiplayer_peer_module(ModuleInitializationLevel level) {
 	if (level == MODULE_INITIALIZATION_LEVEL_SCENE) {
 		ClassDB::register_class<SteamMultiplayerPeer>();
 	}
 }
 
 
-void uninitialize_godotsteam_multiplayer_module(ModuleInitializationLevel level) {
+void uninitialize_godotsteam_multiplayer_peer_module(ModuleInitializationLevel level) {
 }

--- a/register_types.h
+++ b/register_types.h
@@ -5,8 +5,8 @@
 #include "modules/register_module_types.h"
 
 
-void initialize_godotsteam_multiplayer_module(ModuleInitializationLevel level);
-void uninitialize_godotsteam_multiplayer_module(ModuleInitializationLevel level);
+void initialize_godotsteam_multiplayer_peer_module(ModuleInitializationLevel level);
+void uninitialize_godotsteam_multiplayer_peer_module(ModuleInitializationLevel level);
 
 
 #endif


### PR DESCRIPTION
There is a discrepancy with the [docs](https://godotsteam.com/howto/multiplayer_peer/) and compiling.

The docs inform you to clone into `godotsteam_multiplayer_peer` but the code is looking for `godotsteam_multiplayer`.
I've updated the initialization functions to look for `godotsteam_multiplayer_peer` instead as per the docs (and clearer naming) after discussing with @Gramps on the GodotSteam discord.

Thanks,
Mark
