### PR TITLE
FIX: Updated gitignore to ignore python cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@
 export.cfg
 export_presets.cfg
 
+# Python generated
+__pycache__/
+*.pyc
+
 # Imported translations (automatically generated from CSV files)
 *.translation
 


### PR DESCRIPTION
I noticed this repo in particular never ignored the python cache, so I git ignored it like in the other ones.