### PR TITLE
Connection state improvements

### DIFF
--- a/godotsteam_multiplayer_peer.h
+++ b/godotsteam_multiplayer_peer.h
@@ -52,6 +52,7 @@ private:
   int unique_id = 0;
   ConnectionStatus connection_status = CONNECTION_DISCONNECTED;
   bool server = false;
+  int connection_retries = 0;
 
   bool no_nagle = false;
   bool no_delay = false;


### PR DESCRIPTION
With this change the peer will handle server disconnects correctly - causing the `server_disconnected` signal in all cases.

Also implements an automatic reconnect when hitting 4003 errors (will attempt up to five times) - though these are usually avoided by calling `Steam.initRelayNetworkAccess()` in your project after initialization. Should help avoid heartache though!